### PR TITLE
Fix reporting of polls who's results are hidden until completion.

### DIFF
--- a/application.py
+++ b/application.py
@@ -643,7 +643,7 @@ class Application:
 					opt_votes = get_poll_attr(opt, 'votes_count', 0)
 					if is_expired or has_voted:
 						# Show results
-						if votes_count > 0:
+						if votes_count > 0 and opt_votes:
 							pct = (opt_votes / votes_count) * 100
 							opt_text = f"{opt_title}: {pct:.0f}%"
 						else:


### PR DESCRIPTION
A TypeError was thrown when attempting to divide opt_votes by votes_count, because opt_votes is None for these types of polls.
Apparently this None is stored somewhere explicitly because despite get_poll_attr being called with a default of 0 this still occurred.
Fixed by adding a truthiness test for opt_votes to the conditional that actually performs this division, which was already guarding against division by 0.
