### PR TITLE
Fix macOS PyInstaller build with non-Apple arch in PATH

### DIFF
--- a/build.py
+++ b/build.py
@@ -23,6 +23,22 @@ def get_platform():
         return "linux"
 
 
+def get_macos_build_env():
+    """Return an environment that prefers Apple's system tools on macOS.
+
+    PyInstaller's macOS helpers call ``arch`` with Apple-specific flags such as
+    ``-arm64``. If another coreutils implementation appears earlier in PATH,
+    PyInstaller's isolated subprocesses can fail before analysis starts.
+    """
+    env = os.environ.copy()
+    system_paths = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+    current_paths = env.get("PATH", "").split(os.pathsep)
+    env["PATH"] = os.pathsep.join(
+        system_paths + [p for p in current_paths if p and p not in system_paths]
+    )
+    return env
+
+
 def get_git_commit_sha():
     """Get the current git commit SHA."""
     try:
@@ -603,7 +619,7 @@ def build_macos(script_dir: Path, output_dir: Path) -> tuple:
     print()
 
     try:
-        result = subprocess.run(cmd, cwd=script_dir)
+        result = subprocess.run(cmd, cwd=script_dir, env=get_macos_build_env())
     finally:
         # Clean up build_info.txt from source directory
         cleanup_build_info_file(script_dir)


### PR DESCRIPTION
## Summary

Fixes macOS PyInstaller builds when another coreutils implementation appears earlier in PATH than Apple's system tools.

PyInstaller's macOS helpers call arch with Apple-specific flags such as -arm64. If PATH resolves arch to a different implementation, the build can fail before analysis starts.

## Change

The macOS build now runs the PyInstaller subprocess with Apple's system tool directories prepended to PATH, while preserving the caller's existing PATH after those entries.

## Validation

- Confirmed the failure when arch resolves to a non-Apple implementation
- Confirmed the build succeeds when Apple's system arch is preferred
- Ran: .venv/bin/python -m py_compile build.py