### PR TITLE
[codex] Handle Prism speech failures during shutdown

### DIFF
--- a/FastSM.pyw
+++ b/FastSM.pyw
@@ -145,7 +145,7 @@ try:
 	if fastsm_app.prefs.window_shown:
 		main.window.Show()
 	else:
-		speak.speak("Welcome to FastSM! Main window hidden.")
+		speak.speak_async("Welcome to FastSM! Main window hidden.")
 	wx_app.MainLoop()
 except Exception as e:
 	import traceback

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -797,7 +797,7 @@ class MainGui(wx.Frame):
 			speak.speak("Copied")
 
 	def OnClose(self, event=None):
-		speak.speak("Exiting.")
+		speak.speak_async("Exiting.")
 		# Sync timeline positions to server before exiting
 		if get_app().prefs.sync_timeline_position:
 			for account in get_app().accounts:
@@ -864,7 +864,7 @@ class MainGui(wx.Frame):
 	def OnPlayExternal(self,event=None):
 		status = self.get_current_status()
 		if status:
-			thread=threading.Thread(target=misc.play_external,args=(status,)).start()
+			thread=threading.Thread(target=misc.play_external,args=(status,),daemon=True).start()
 
 	def OnStopAudio(self,event=None):
 		sound.stop()

--- a/application.py
+++ b/application.py
@@ -1875,7 +1875,7 @@ class Application:
 
 				# Move from temp to app directory
 				shutil.move(zip_path, final_zip_path)
-				speak.speak("Download complete. Preparing update...")
+				speak.speak_async("Download complete. Preparing update...")
 
 				# Create updater batch script
 				batch_path = os.path.join(app_dir, "updater.bat")
@@ -1934,11 +1934,11 @@ del "%~f0"
 				with open(batch_path, 'w') as f:
 					f.write(batch_content)
 
-				speak.speak("Update ready. FastSM will now restart.")
 				# Run the updater and exit cleanly (OnClose handles cleanup like saving positions)
 				os.startfile(batch_path)
 				from GUI import main
 				wx.CallAfter(main.window.OnClose)
+				speak.speak_async("Update ready. FastSM will now restart.")
 				# Belt-and-suspenders: OnClose ends in sys.exit(), but if a
 				# rogue non-daemon thread (atproto websocket, sound backend,
 				# COM finalizer) keeps the process alive, the batch's wait
@@ -2098,7 +2098,7 @@ del "%~f0"
 				return
 
 			wx.CallAfter(close_progress_dialog)
-			speak.speak("Download complete. Preparing update...")
+			speak.speak_async("Download complete. Preparing update...")
 
 			# Confirm we can write to the install dir before staging the
 			# script. If we're in /opt or /usr, the swap will fail and we'd
@@ -2177,8 +2177,6 @@ rm -f "$0"
 				f.write(script)
 			os.chmod(script_path, os.stat(script_path).st_mode | _stat.S_IXUSR | _stat.S_IXGRP | _stat.S_IXOTH)
 
-			speak.speak("Update ready. FastSM will now restart.")
-
 			# Detach via setsid + DEVNULL so the script outlives this
 			# process. Don't wait() — the script's whole job is to wait
 			# for *us* to exit.
@@ -2193,6 +2191,7 @@ rm -f "$0"
 
 			from GUI import main
 			wx.CallAfter(main.window.OnClose)
+			speak.speak_async("Update ready. FastSM will now restart.")
 
 			# Same belt-and-suspenders as Windows: if a non-daemon thread
 			# wedges OnClose, force-quit so the script's wait loop falls
@@ -2269,7 +2268,6 @@ rm -f "$0"
 				return
 
 			wx.CallAfter(close_progress_dialog)
-			speak.speak("Download complete. Running installer...")
 
 			# Run the installer silently and close the app
 			# /SILENT shows progress but no user interaction
@@ -2287,6 +2285,7 @@ rm -f "$0"
 			# Close the app to allow installer to update files
 			from GUI import main
 			wx.CallAfter(main.window.OnClose)
+			speak.speak_async("Download complete. Running installer...")
 
 		except Exception as e:
 			wx.CallAfter(close_progress_dialog)

--- a/speak.py
+++ b/speak.py
@@ -12,32 +12,40 @@ prism's own ranking (which picks the active screen reader when one is running).
 AV Speech on macOS must be driven from the main thread, so off-thread callers
 are marshalled via wx.CallAfter.
 
-The backend is re-detected dynamically: if speak() raises PrismError (the
-screen reader quit, the audio device went away, etc.) we drop the cached
-backend and try again. We also periodically re-check whether a higher-priority
-backend has appeared since we last picked one, so a screen reader that starts
-after FastSM doesn't leave us stuck on a fallback.
+The backend is re-detected dynamically: if the backend raises (the screen
+reader quit, the audio device went away, prism exposed a native/DBus failure,
+etc.) we drop the cached backend and try again. We also periodically re-check
+whether a higher-priority backend has appeared since we last picked one, so a
+screen reader that starts after FastSM doesn't leave us stuck on a fallback.
 """
 
+import importlib
+import logging
 import sys
 import threading
 import time
 
-import prism
-
 
 _main_thread_id = threading.main_thread().ident
-_context = prism.Context()
+_prism = None
+_context = None
 _prism_backend = None
 _prism_backend_id = None
 _last_recheck = 0.0
 _RECHECK_INTERVAL = 5.0
+_PRISM_FAILURE_BACKOFF = 30.0
+_prism_backoff_until = 0.0
 _lock = threading.Lock()
+_logger = logging.getLogger("fastsm.speech")
 
 # Legacy accessible_output2 backend, lazily imported so the dependency is only
 # loaded when the user actually opts into it.
 _a2_speaker = None
 _a2_imported = False
+
+
+class _SpeechBackendUnavailable(Exception):
+	pass
 
 
 def _use_legacy():
@@ -68,34 +76,73 @@ def _get_a2_speaker():
 	return _a2_speaker
 
 
+def _prism_backoff_active():
+	return time.monotonic() < _prism_backoff_until
+
+
+def _log_prism_failure(action, error, backoff=False):
+	try:
+		extra = " Temporarily disabling prism speech." if backoff else ""
+		fastsm_logger = logging.getLogger("fastsm")
+		if not fastsm_logger.handlers:
+			return
+		_logger.warning("Prism speech %s failed: %s.%s", action, error, extra)
+		_logger.debug("Prism speech %s traceback", action, exc_info=True)
+	except Exception:
+		pass
+
+
+def _get_prism_module():
+	global _prism
+	if _prism_backoff_active():
+		raise _SpeechBackendUnavailable("prism speech is in failure backoff")
+	if _prism is None:
+		_prism = importlib.import_module("prism")
+	return _prism
+
+
+def _get_context():
+	global _context
+	if _context is None:
+		_context = _get_prism_module().Context()
+	return _context
+
+
 def _create_backend():
 	"""Create the best available backend, preferring VoiceOver on macOS.
 
 	Returns (backend, backend_id) so we can tell later whether a more-preferred
 	backend has come online without rebuilding the current one to compare.
 	"""
-	if sys.platform == 'darwin' and _context.exists(prism.BackendId.VOICE_OVER):
+	prism = _get_prism_module()
+	context = _get_context()
+	if sys.platform == 'darwin':
 		try:
-			return _context.create(prism.BackendId.VOICE_OVER), prism.BackendId.VOICE_OVER
-		except prism.PrismError:
+			if context.exists(prism.BackendId.VOICE_OVER):
+				return context.create(prism.BackendId.VOICE_OVER), prism.BackendId.VOICE_OVER
+		except Exception as error:
+			_log_prism_failure("VoiceOver detection", error)
 			pass
-	backend = _context.create_best()
+	backend = context.create_best()
 	return backend, getattr(backend, 'id', None)
 
 
 def _preferred_backend_changed():
 	"""Return True if a higher-priority backend than the cached one is now available."""
+	prism = _get_prism_module()
+	context = _get_context()
 	if sys.platform == 'darwin' and _prism_backend_id != prism.BackendId.VOICE_OVER:
 		try:
-			if _context.exists(prism.BackendId.VOICE_OVER):
+			if context.exists(prism.BackendId.VOICE_OVER):
 				return True
-		except prism.PrismError:
+		except Exception as error:
+			_log_prism_failure("VoiceOver recheck", error)
 			return False
 	return False
 
 
 def _get_prism_backend():
-	global _prism_backend, _prism_backend_id, _last_recheck
+	global _prism_backend, _prism_backend_id, _last_recheck, _context
 	with _lock:
 		now = time.monotonic()
 		if _prism_backend is not None and now - _last_recheck >= _RECHECK_INTERVAL:
@@ -104,21 +151,31 @@ def _get_prism_backend():
 				_prism_backend = None
 				_prism_backend_id = None
 		if _prism_backend is None:
-			_prism_backend, _prism_backend_id = _create_backend()
-			_last_recheck = time.monotonic()
+			try:
+				_prism_backend, _prism_backend_id = _create_backend()
+				_last_recheck = time.monotonic()
+			except Exception:
+				_context = None
+				raise
 		return _prism_backend
 
 
-def _invalidate_backend():
-	global _prism_backend, _prism_backend_id
+def _invalidate_backend(reset_context=False, backoff=False, reset_backoff=False):
+	global _context, _prism_backend, _prism_backend_id, _prism_backoff_until
 	with _lock:
 		_prism_backend = None
 		_prism_backend_id = None
+		if reset_context:
+			_context = None
+		if reset_backoff:
+			_prism_backoff_until = 0.0
+		if backoff:
+			_prism_backoff_until = time.monotonic() + _PRISM_FAILURE_BACKOFF
 
 
 def reset_backend():
 	"""Force re-detection of the speech backend on the next speak() call."""
-	_invalidate_backend()
+	_invalidate_backend(reset_context=True, reset_backoff=True)
 
 
 def _try_speak(text, interrupt):
@@ -157,13 +214,22 @@ def _do_speak(text, interrupt):
 		# the user still hears something instead of going silent.
 	try:
 		_try_speak(text, interrupt)
-	except prism.PrismError:
-		# The current backend died (screen reader closed, audio bus dropped,
-		# etc.). Drop it and retry once with a fresh pick.
+	except _SpeechBackendUnavailable:
+		pass
+	except Exception as error:
+		# The current backend died or prism exposed a native/DBus backend
+		# failure outside PrismError (for example an unsupported Orca DBus API).
+		# Drop it and retry once with a fresh pick, but never let speech output
+		# abort callers such as application shutdown.
+		_log_prism_failure("output", error)
 		_invalidate_backend()
 		try:
 			_try_speak(text, interrupt)
-		except prism.PrismError:
+		except _SpeechBackendUnavailable:
+			pass
+		except Exception as retry_error:
+			_log_prism_failure("retry", retry_error, backoff=True)
+			_invalidate_backend(reset_context=True, backoff=True)
 			pass
 
 
@@ -176,3 +242,11 @@ def speak(text, interrupt=False):
 			_do_speak(text, interrupt)
 	else:
 		_do_speak(text, interrupt)
+
+
+def speak_async(text, interrupt=False):
+	"""Best-effort speech for non-critical paths that must never block callers."""
+	try:
+		threading.Thread(target=speak, args=(text, interrupt), daemon=True).start()
+	except Exception as error:
+		_log_prism_failure("async dispatch", error)

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -1,0 +1,188 @@
+import importlib
+import sys
+import threading
+import types
+import unittest
+
+
+class _BackendId:
+	VOICE_OVER = "voice_over"
+
+
+class _PrismError(Exception):
+	pass
+
+
+def _load_speak_with_context(context_cls):
+	fake_prism = types.SimpleNamespace(
+		BackendId=_BackendId,
+		Context=context_cls,
+		PrismError=_PrismError,
+	)
+	sys.modules.pop("speak", None)
+	sys.modules["prism"] = fake_prism
+	speak = importlib.import_module("speak")
+	speak._logger.disabled = True
+	return speak
+
+
+class SpeakPrismFailureTests(unittest.TestCase):
+	def tearDown(self):
+		sys.modules.pop("speak", None)
+		sys.modules.pop("prism", None)
+
+	def test_non_prism_backend_errors_are_swallowed_after_retry(self):
+		speak_calls = []
+
+		class Backend:
+			id = "orca"
+
+			def speak(self, text, interrupt):
+				speak_calls.append((text, interrupt))
+				raise RuntimeError("unsupported Orca DBus API")
+
+			def braille(self, text):
+				pass
+
+		class Context:
+			create_count = 0
+
+			def create_best(self):
+				type(self).create_count += 1
+				return Backend()
+
+		speak = _load_speak_with_context(Context)
+
+		speak.speak("Exiting.", interrupt=True)
+
+		self.assertEqual(Context.create_count, 2)
+		self.assertEqual(len(speak_calls), 2)
+		self.assertIsNone(speak._prism_backend)
+
+	def test_non_prism_backend_creation_errors_are_swallowed(self):
+		class Context:
+			create_count = 0
+
+			def create_best(self):
+				type(self).create_count += 1
+				raise RuntimeError("unsupported Orca DBus API")
+
+		speak = _load_speak_with_context(Context)
+
+		speak.speak("Exiting.")
+
+		self.assertEqual(Context.create_count, 2)
+		self.assertIsNone(speak._prism_backend)
+
+	def test_retry_success_keeps_new_backend_cached(self):
+		class BrokenBackend:
+			id = "orca"
+
+			def speak(self, text, interrupt):
+				raise RuntimeError("unsupported Orca DBus API")
+
+			def braille(self, text):
+				pass
+
+		class WorkingBackend:
+			id = "speech_dispatcher"
+			speak_calls = 0
+
+			def speak(self, text, interrupt):
+				type(self).speak_calls += 1
+
+			def braille(self, text):
+				pass
+
+		class Context:
+			create_count = 0
+
+			def create_best(self):
+				type(self).create_count += 1
+				if type(self).create_count == 1:
+					return BrokenBackend()
+				return WorkingBackend()
+
+		speak = _load_speak_with_context(Context)
+
+		speak.speak("Hello")
+
+		self.assertEqual(Context.create_count, 2)
+		self.assertEqual(WorkingBackend.speak_calls, 1)
+		self.assertIsInstance(speak._prism_backend, WorkingBackend)
+
+	def test_import_time_does_not_require_prism(self):
+		sys.modules.pop("speak", None)
+		sys.modules.pop("prism", None)
+
+		speak = importlib.import_module("speak")
+		speak._logger.disabled = True
+		original_import_module = importlib.import_module
+		def fail_import(name):
+			raise RuntimeError(f"cannot import {name}")
+		importlib.import_module = fail_import
+
+		try:
+			speak.speak("Exiting.")
+		finally:
+			importlib.import_module = original_import_module
+
+		self.assertIsNone(speak._prism_backend)
+
+	def test_backoff_skips_repeated_prism_creation_attempts(self):
+		class Context:
+			create_count = 0
+
+			def create_best(self):
+				type(self).create_count += 1
+				raise RuntimeError("unsupported Orca DBus API")
+
+		speak = _load_speak_with_context(Context)
+
+		speak.speak("first failure")
+		speak.speak("during backoff")
+
+		self.assertEqual(Context.create_count, 2)
+
+	def test_prism_failure_does_not_show_dialogs(self):
+		class DialogSentinel:
+			def __getattr__(self, name):
+				if name in ("MessageBox", "MessageDialog"):
+					raise AssertionError(f"unexpected dialog: {name}")
+				raise AttributeError(name)
+
+		class Context:
+			def create_best(self):
+				raise RuntimeError("unsupported Orca DBus API")
+
+		sys.modules["wx"] = DialogSentinel()
+		try:
+			speak = _load_speak_with_context(Context)
+
+			speak.speak("Exiting.")
+		finally:
+			sys.modules.pop("wx", None)
+
+	def test_speak_async_start_failure_is_swallowed(self):
+		class FailingThread:
+			def __init__(self, *args, **kwargs):
+				pass
+
+			def start(self):
+				raise RuntimeError("cannot start thread")
+
+		class Context:
+			def create_best(self):
+				raise AssertionError("speech should not be attempted")
+
+		speak = _load_speak_with_context(Context)
+		original_thread = threading.Thread
+		threading.Thread = FailingThread
+		try:
+			speak.speak_async("non-critical")
+		finally:
+			threading.Thread = original_thread
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary

This PR makes FastSM's speech output resilient to Prism and screen-reader failures, especially Orca DBus/API incompatibilities that could previously surface as unhandled exceptions during shutdown.

## What changed

- Make Prism import and context creation lazy so `import speak` remains safe even if Prism or the active screen reader is broken.
- Treat Prism/backend failures as best-effort speech failures: invalidate the cached backend, retry once, then enter a short silent backoff.
- Keep diagnostics in logs without showing large console tracebacks by default; full traceback detail is only logged at debug level.
- Preserve user-facing announcements while moving non-critical startup, shutdown, and update speech to `speak_async()` so these paths do not block exit or update handoff.
- Make the external audio playback worker daemon so a blocked speech/audio path cannot keep the process alive after shutdown.
- Add regression tests for Prism import, backend creation, backend speak failures, retry behavior, backoff, dialog avoidance, and async dispatch failures.

## Root cause

`speak.py` previously imported Prism and created a Prism context at module import time, then only caught `prism.PrismError` during speech. Some Orca/DBus failures can happen before the wrapper runs or can be exposed as different exception types. Shutdown also announced `Exiting.` synchronously before cleanup, so a broken or blocking speech backend could prevent the application from closing.

## Validation

- `python -m unittest discover -s tests`
- `python -m py_compile speak.py GUI/main.py application.py FastSM.pyw tests/test_speak.py`
- Manual: verified that the main window can be closed successfully after the Prism/Orca failure handling changes.
