### PR TITLE
[codex] Add wxPython Linux source-build fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,27 @@ jobs:
           # wxPython's extras page is a plain directory listing, not a PEP 503
           # simple index — so it must be passed via --find-links, not
           # --extra-index-url. Pin 4.2.2 since that's the newest wheel there.
-          pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxpython==4.2.2
+          # If the extras host is unavailable, build wxPython from the sdist
+          # using the same family of Ubuntu build dependencies as Phoenix CI.
+          if ! pip install --only-binary wxPython -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython==4.2.2; then
+            sudo apt-get install -y \
+              build-essential \
+              dpkg-dev \
+              freeglut3-dev \
+              libcurl4-openssl-dev \
+              libexpat1-dev \
+              libgtk-3-dev \
+              libjpeg-dev \
+              libnotify-dev \
+              libpng-dev \
+              libsecret-1-dev \
+              libsdl2-dev \
+              libsm-dev \
+              libtiff-dev \
+              libwebkit2gtk-4.0-dev \
+              libxtst-dev
+            pip install wxPython==4.2.2
+          fi
           pip install -r requirements.txt
           # Needed by build.py's post-build libprism rewrite.
           pip install patchelf


### PR DESCRIPTION
## What changed

- Keep installing the Linux wxPython wheel from extras.wxpython.org as the preferred path.
- If that wheel install fails, install the Ubuntu build dependencies used by the wxPython/Phoenix build flow and compile wxPython==4.2.2 from the sdist.

## Why

Recent scheduled release runs failed because extras.wxpython.org timed out or was unreachable. Pip then fell back to the wxPython source distribution, but the runner only had GTK runtime libraries, not the development headers needed to compile wxPython.

## Impact

The normal fast path remains unchanged when the upstream wheel host is available. When it is not, the Linux release build can still proceed on the Ubuntu 22.04 runner instead of blocking the full latest release.

## Validation

- git diff --check