### PR TITLE
[codex] Unpin Linux wxPython install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,10 +191,10 @@ jobs:
           python -m pip install --upgrade pip
           # wxPython's extras page is a plain directory listing, not a PEP 503
           # simple index — so it must be passed via --find-links, not
-          # --extra-index-url. Pin 4.2.2 since that's the newest wheel there.
-          # If the extras host is unavailable, build wxPython from the sdist
+          # --extra-index-url. Prefer the latest available wxPython wheel there.
+          # If the extras host is unavailable, wxPython will be built from the sdist when installing requirements
           # using the same family of Ubuntu build dependencies as Phoenix CI.
-          if ! pip install --only-binary wxPython -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython==4.2.2; then
+          if ! pip install --only-binary wxPython -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython; then
             sudo apt-get install -y \
               build-essential \
               dpkg-dev \
@@ -211,7 +211,6 @@ jobs:
               libtiff-dev \
               libwebkit2gtk-4.0-dev \
               libxtst-dev
-            pip install wxPython==4.2.2
           fi
           pip install -r requirements.txt
           # Needed by build.py's post-build libprism rewrite.


### PR DESCRIPTION
## What changed

- Stop pinning the Linux CI wxPython install to 4.2.2.
- Keep the preferred path of installing a binary wheel from the wxPython extras directory.
- Keep the source-build fallback dependencies from the previous CI fix, but let the later requirements install build the current compatible wxPython release from the sdist if the extras host is unavailable.

## Why

The previous fallback fix moved the Linux job past the missing GTK development headers, but the source build still failed while packaging wxPython 4.2.2:

```text
TypeError: copy_file() takes from 2 to 7 positional arguments but 8 were given
```

That failure is caused by wxPython 4.2.2 interacting badly with newer setuptools in pip's isolated build environment. The wxPython extras directory now contains newer 4.2.x wheels, including releases that address this setuptools compatibility issue, so the hard pin is no longer correct.

## Impact

The fast path still uses the wxPython extras wheels when available. If that host is unavailable, the fallback no longer forces the known-broken 4.2.2 source build and instead follows the unpinned project requirement.

## Validation

- `git diff --check`
