### PR TITLE
Change automated release schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - '.gitattributes'
       - 'LICENSE'
   schedule:
-    - cron: '0 6 * * *'     # daily at 06:00 UTC: build + publish release
+    - cron: '37 6 * * *'     # daily at 06:37 UTC: build + publish release
   workflow_dispatch:        # manual trigger: build + publish release
 
 permissions:


### PR DESCRIPTION
The [GitHub doc](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule) specify a scheduled job can be dropped in case of overload period.
Today no release has been publied, no error because no scheduled job has been executed.

If possible to make a manual dispatch to publish a new release please.
#43 fixes a particularly anoying bug which prevents quiting the app on Linux with Orca main.
