### PR TITLE
[codex] Sequence shutdown speech safely

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           fi
 
   build-windows:
-    needs: gate
+    needs: [gate, unit-tests]
     if: needs.gate.outputs.should_run == 'true'
     runs-on: windows-latest
 
@@ -123,8 +123,33 @@ jobs:
           name: windows-installer
           path: ${{ steps.artifact.outputs.installer_path }}
 
-  build-macos:
+  unit-tests:
     needs: gate
+    if: needs.gate.outputs.should_run == 'true'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --only-binary wxPython -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run unit tests
+        run: python -m pytest tests/test_speak.py -q
+
+  build-macos:
+    needs: [gate, unit-tests]
     if: needs.gate.outputs.should_run == 'true'
     runs-on: macos-latest
 
@@ -160,7 +185,7 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
 
   build-linux:
-    needs: gate
+    needs: [gate, unit-tests]
     if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-22.04
 
@@ -255,7 +280,7 @@ jobs:
     # commits since the last release, so reaching this job at all means
     # the artifacts are worth publishing.
     if: github.event_name != 'push' && needs.gate.outputs.should_run == 'true'
-    needs: [gate, build-windows, build-macos, build-linux]
+    needs: [gate, unit-tests, build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
 
     steps:

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -3,7 +3,6 @@ import re
 import webbrowser
 import platform
 import pyperclip
-import sys
 import application
 from application import get_app
 import wx
@@ -60,6 +59,7 @@ def safe_raise_window(win):
 class MainGui(wx.Frame):
 	def __init__(self, title):
 		self.invisible=False
+		self._closing = False
 		self._find_text = ""  # Current search text for find in timeline
 		self._open_dialogs = []  # Track open dialogs for focus restoration
 		wx.Frame.__init__(self, None, title=title,size=(800,600))
@@ -796,8 +796,11 @@ class MainGui(wx.Frame):
 			pyperclip.copy(get_app().template_to_string(status, template))
 			speak.speak("Copied")
 
-	def OnClose(self, event=None):
-		speak.speak_async("Exiting.")
+	def OnClose(self, event=None, shutdown_message="Exiting."):
+		if self._closing:
+			return
+		self._closing = True
+		speak.speak_before_shutdown(shutdown_message)
 		# Sync timeline positions to server before exiting
 		if get_app().prefs.sync_timeline_position:
 			for account in get_app().accounts:
@@ -847,7 +850,15 @@ class MainGui(wx.Frame):
 					except Exception as e:
 						print(f"Error cleaning up cache: {e}")
 		if platform.system()!="Darwin" and self.trayicon is not None:
-			self.trayicon.on_exit(event,False)
+			try:
+				self.trayicon.RemoveIcon()
+			except Exception:
+				pass
+			try:
+				self.trayicon.Destroy()
+			except Exception:
+				pass
+			self.trayicon = None
 		# Clean up account resources (close timeline caches)
 		for account in get_app().accounts:
 			if hasattr(account, 'cleanup'):
@@ -856,10 +867,7 @@ class MainGui(wx.Frame):
 				except:
 					pass
 		self.Destroy()
-		# On Mac, we need to explicitly exit the main loop
-		if platform.system() == "Darwin":
-			wx.GetApp().ExitMainLoop()
-		sys.exit()
+		wx.CallAfter(wx.GetApp().ExitMainLoop)
 	
 	def OnPlayExternal(self,event=None):
 		status = self.get_current_status()

--- a/GUI/tray.py
+++ b/GUI/tray.py
@@ -34,9 +34,10 @@ class TaskBarIcon(wx.adv.TaskBarIcon):
 		self.frame.ToggleWindow()
 
 	def on_exit(self, event, blah=True):
-		self.Destroy()
 		if blah:
 			self.frame.OnClose(event)
+		else:
+			self.Destroy()
 
 	def set_icon(self, path):
 #		icon = wx.Icon(wx.Bitmap(path))

--- a/application.py
+++ b/application.py
@@ -1937,14 +1937,12 @@ del "%~f0"
 				# Run the updater and exit cleanly (OnClose handles cleanup like saving positions)
 				os.startfile(batch_path)
 				from GUI import main
-				wx.CallAfter(main.window.OnClose)
-				speak.speak_async("Update ready. FastSM will now restart.")
-				# Belt-and-suspenders: OnClose ends in sys.exit(), but if a
-				# rogue non-daemon thread (atproto websocket, sound backend,
-				# COM finalizer) keeps the process alive, the batch's wait
-				# loop hangs. Force-terminate after a grace window so cache
-				# writes have time to flush but a stuck shutdown doesn't
-				# wedge the update.
+				wx.CallAfter(main.window.OnClose, None, "Update ready. FastSM will now restart.")
+				# Belt-and-suspenders: if a rogue non-daemon thread (atproto
+				# websocket, sound backend, COM finalizer) keeps the process
+				# alive, the batch's wait loop hangs. Force-terminate after a
+				# grace window so cache writes have time to flush but a stuck
+				# shutdown doesn't wedge the update.
 				def _force_quit_after(delay):
 					time.sleep(delay)
 					os._exit(0)
@@ -2190,8 +2188,7 @@ rm -f "$0"
 			)
 
 			from GUI import main
-			wx.CallAfter(main.window.OnClose)
-			speak.speak_async("Update ready. FastSM will now restart.")
+			wx.CallAfter(main.window.OnClose, None, "Update ready. FastSM will now restart.")
 
 			# Same belt-and-suspenders as Windows: if a non-daemon thread
 			# wedges OnClose, force-quit so the script's wait loop falls
@@ -2284,8 +2281,7 @@ rm -f "$0"
 
 			# Close the app to allow installer to update files
 			from GUI import main
-			wx.CallAfter(main.window.OnClose)
-			speak.speak_async("Download complete. Running installer...")
+			wx.CallAfter(main.window.OnClose, None, "Download complete. Running installer...")
 
 		except Exception as e:
 			wx.CallAfter(close_progress_dialog)

--- a/speak.py
+++ b/speak.py
@@ -36,6 +36,7 @@ _RECHECK_INTERVAL = 5.0
 _PRISM_FAILURE_BACKOFF = 30.0
 _prism_backoff_until = 0.0
 _lock = threading.Lock()
+_shutdown_started = False
 _logger = logging.getLogger("fastsm.speech")
 
 # Legacy accessible_output2 backend, lazily imported so the dependency is only
@@ -202,7 +203,23 @@ def _speak_via_a2(text, interrupt):
 		return False
 
 
-def _do_speak(text, interrupt):
+def _shutdown_active():
+	with _lock:
+		return _shutdown_started
+
+
+def _start_shutdown():
+	global _shutdown_started
+	with _lock:
+		if _shutdown_started:
+			return False
+		_shutdown_started = True
+		return True
+
+
+def _do_speak(text, interrupt, retry=True, allow_shutdown=False):
+	if _shutdown_active() and not allow_shutdown:
+		return
 	# Backend creation is deferred to first speak() because prism's macOS
 	# VoiceOver backend needs an NSWindow to exist when create() is called —
 	# warming up at import time runs before GUI.main has built the wxFrame,
@@ -222,6 +239,9 @@ def _do_speak(text, interrupt):
 		# Drop it and retry once with a fresh pick, but never let speech output
 		# abort callers such as application shutdown.
 		_log_prism_failure("output", error)
+		if not retry:
+			_invalidate_backend(reset_context=True, backoff=True)
+			return
 		_invalidate_backend()
 		try:
 			_try_speak(text, interrupt)
@@ -234,19 +254,45 @@ def _do_speak(text, interrupt):
 
 
 def speak(text, interrupt=False):
+	if _shutdown_active():
+		return
 	if sys.platform == 'darwin' and threading.current_thread().ident != _main_thread_id:
 		try:
 			import wx
 			wx.CallAfter(_do_speak, text, interrupt)
 		except Exception:
-			_do_speak(text, interrupt)
+			if not _shutdown_active():
+				_do_speak(text, interrupt)
 	else:
 		_do_speak(text, interrupt)
 
 
 def speak_async(text, interrupt=False):
 	"""Best-effort speech for non-critical paths that must never block callers."""
+	if _shutdown_active():
+		return
 	try:
 		threading.Thread(target=speak, args=(text, interrupt), daemon=True).start()
 	except Exception as error:
 		_log_prism_failure("async dispatch", error)
+
+
+def speak_before_shutdown(text, interrupt=False, timeout=0.5):
+	"""Speak one shutdown announcement before suppressing any later speech.
+
+	The announcement is allowed a short grace window, but shutdown must continue
+	even if a native speech backend blocks.
+	"""
+	if not _start_shutdown():
+		return
+	try:
+		thread = threading.Thread(
+			target=_do_speak,
+			args=(text, interrupt),
+			kwargs={"retry": False, "allow_shutdown": True},
+			daemon=True,
+		)
+		thread.start()
+		thread.join(timeout)
+	except Exception as error:
+		_log_prism_failure("shutdown dispatch", error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))

--- a/tests/test_speak.py
+++ b/tests/test_speak.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import threading
+import time
 import types
 import unittest
 
@@ -180,6 +181,133 @@ class SpeakPrismFailureTests(unittest.TestCase):
 		threading.Thread = FailingThread
 		try:
 			speak.speak_async("non-critical")
+		finally:
+			threading.Thread = original_thread
+
+	def test_shutdown_announcement_blocks_later_speech(self):
+		speak_calls = []
+
+		class Backend:
+			id = "speech_dispatcher"
+
+			def speak(self, text, interrupt):
+				speak_calls.append((text, interrupt))
+
+			def braille(self, text):
+				pass
+
+		class Context:
+			def create_best(self):
+				return Backend()
+
+		speak = _load_speak_with_context(Context)
+
+		speak.speak_before_shutdown("Exiting.", interrupt=True)
+		speak.speak("late speech")
+		speak.speak_async("late async speech")
+		speak._do_speak("queued before shutdown", False)
+
+		self.assertEqual(speak_calls, [("Exiting.", True)])
+
+	def test_shutdown_announcement_does_not_retry_broken_backend(self):
+		class Context:
+			create_count = 0
+
+			def create_best(self):
+				type(self).create_count += 1
+				raise RuntimeError("unsupported Orca DBus API")
+
+		speak = _load_speak_with_context(Context)
+
+		speak.speak_before_shutdown("Exiting.")
+
+		self.assertEqual(Context.create_count, 1)
+		self.assertIsNone(speak._prism_backend)
+
+	def test_shutdown_announcement_has_bounded_wait(self):
+		started = threading.Event()
+		release = threading.Event()
+
+		class Backend:
+			id = "speech_dispatcher"
+
+			def speak(self, text, interrupt):
+				started.set()
+				release.wait(1.0)
+
+			def braille(self, text):
+				pass
+
+		class Context:
+			def create_best(self):
+				return Backend()
+
+		speak = _load_speak_with_context(Context)
+
+		start = time.monotonic()
+		try:
+			speak.speak_before_shutdown("Exiting.", timeout=0.01)
+			elapsed = time.monotonic() - start
+			self.assertLess(elapsed, 0.2)
+			self.assertTrue(started.wait(0.2))
+		finally:
+			release.set()
+
+	def test_shutdown_announcement_has_bounded_wait_on_darwin(self):
+		started = threading.Event()
+		release = threading.Event()
+
+		class Backend:
+			id = "voice_over"
+
+			def speak(self, text, interrupt):
+				started.set()
+				release.wait(1.0)
+
+			def braille(self, text):
+				pass
+
+		class Context:
+			def exists(self, backend_id):
+				return False
+
+			def create_best(self):
+				return Backend()
+
+		speak = _load_speak_with_context(Context)
+		original_platform = sys.platform
+		sys.platform = "darwin"
+
+		start = time.monotonic()
+		try:
+			speak.speak_before_shutdown("Exiting.", timeout=0.01)
+			elapsed = time.monotonic() - start
+			self.assertLess(elapsed, 0.2)
+			self.assertTrue(started.wait(0.2))
+		finally:
+			sys.platform = original_platform
+			release.set()
+
+	def test_shutdown_announcement_start_failure_is_swallowed(self):
+		class FailingThread:
+			def __init__(self, *args, **kwargs):
+				pass
+
+			def start(self):
+				raise RuntimeError("cannot start thread")
+
+			def join(self, timeout=None):
+				raise AssertionError("join should not run after start failure")
+
+		class Context:
+			def create_best(self):
+				raise AssertionError("speech should not be attempted")
+
+		speak = _load_speak_with_context(Context)
+		original_thread = threading.Thread
+		threading.Thread = FailingThread
+		try:
+			speak.speak_before_shutdown("Exiting.")
 		finally:
 			threading.Thread = original_thread
 


### PR DESCRIPTION
## Summary

- keep shutdown/update voice announcements but dispatch them through a bounded shutdown speech path
- make main-window shutdown non-reentrant, clean tray ownership directly, and leave wx via ExitMainLoop instead of sys.exit from the event handler
- add targeted speech shutdown tests plus a CI unit-test job for the regression suite

## Root cause

PR #43 made Prism exceptions best-effort, but shutdown still launched speech asynchronously while wx/GTK/Prism were being torn down. Native speech backends can segfault outside Python exception handling, and wx shutdown could also be re-entered through tray/hotkey/update paths.

## Relation to #39

Issue #39 reports repeated Linux `GLib-CRITICAL ... g_ptr_array_unref: assertion 'array' failed` messages while browsing posts. Those symptoms point at the same native GLib/Prism/Orca speech stack involved in the shutdown crash: Python can catch Prism wrapper exceptions, but it cannot recover once the underlying GLib-backed speech path is called at the wrong time or keeps running during teardown.

This PR does not remove voice announcements. Instead, it makes the shutdown announcement bounded, suppresses any later speech dispatch once shutdown begins, avoids retrying Prism during shutdown, and exits wx cleanly. Real-world testing by Patrick and @jeremyp3 confirms the shutdown fix, and the same testing indicates this also resolves the GLib critical behavior from #39 as a positive side effect.

Fixes #39 after confirmation by @jeremyp3.

## Validation

- Real-world test by myself: shutdown no longer segfaults while keeping the voice announcement
- Real-world test by @jeremyp3: confirms the fix and that #39 appears resolved
- `python -m pytest tests/test_speak.py -q`
- `python -m unittest discover -s tests`
- `python -m py_compile speak.py GUI/main.py GUI/tray.py application.py tests/test_speak.py tests/conftest.py`
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml')); print('yaml ok')"`
- `git diff --check`
- CodeRabbit review: 0 issues after fixes
- successive agent reviews: OK final
