### PR TITLE
Add Fusion View timeline

### DIFF
--- a/GUI/accounts.py
+++ b/GUI/accounts.py
@@ -92,13 +92,13 @@ class AccountsGui(wx.Dialog):
 	def New(self, event):
 		app = get_app()
 		num_accounts_before = len(app.accounts)
-		app.add_session()
+		new_account = app.add_session()
 		# Check if a new account was actually added
-		if len(app.accounts) <= num_accounts_before:
+		if new_account is None or len(app.accounts) <= num_accounts_before:
 			# Account creation was cancelled or failed
 			return
 		app.prefs.accounts+=1
-		app.currentAccount=app.accounts[len(app.accounts)-1]
+		app.currentAccount=new_account
 		main.window.refreshTimelines()
 		main.window.on_list_change(None)
 		main.window.SetLabel(app.currentAccount.me.acct+" - "+application.name+" "+application.version)
@@ -132,6 +132,9 @@ class AccountsGui(wx.Dialog):
 
 		account_to_remove = app.accounts[selection]
 		account_name = account_to_remove.me.acct
+		if getattr(account_to_remove, 'is_virtual', False):
+			speak.speak("Fusion View cannot be removed")
+			return
 		# Folder number on disk — may differ from the list selection because
 		# parallel-loaded accounts can land in app.accounts in completion order.
 		# Falling back on selection here would delete the right object in memory

--- a/GUI/invisible.py
+++ b/GUI/invisible.py
@@ -127,6 +127,8 @@ class invisible_interface(object):
 			speak.speak(get_app().process_notification(item, account=account), True)
 		elif tl_type in ("messages", "conversations"):
 			speak.speak(get_app().process_conversation(item, account=account), True)
+		elif tl_type == "fusion":
+			speak.speak(getattr(item, '_display_cache', None) or item.accessible_label(), True)
 		else:
 			# mentions now treated same as home/user/etc.
 			speak.speak(get_app().process_status(item, account=account), True)

--- a/GUI/main.py
+++ b/GUI/main.py
@@ -564,6 +564,11 @@ class MainGui(wx.Frame):
 		if not tl.statuses or tl.index >= len(tl.statuses):
 			return None
 		item = tl.statuses[tl.index]
+		if tl.type == "fusion":
+			original = getattr(item, 'original', None)
+			if getattr(item, 'item_type', None) == "notifications" and hasattr(original, 'status'):
+				return original.status
+			return original
 		if get_app().currentAccount.currentTimeline.type == "conversations":
 			# Conversations have last_status instead of being a status directly
 			if hasattr(item, 'last_status') and item.last_status:
@@ -576,6 +581,14 @@ class MainGui(wx.Frame):
 			# For follow notifications etc. without a status, return None
 			return None
 		return item
+
+	def get_current_status_account(self):
+		"""Return the source account for the selected item."""
+		account = get_app().currentAccount
+		tl = account.currentTimeline
+		if tl and tl.type == "fusion" and tl.statuses and tl.index < len(tl.statuses):
+			return getattr(tl.statuses[tl.index], 'source_account', account)
+		return account
 
 	def _sync_status_state_across_buffers(self, account, status_id, **state_updates):
 		"""Sync status state (favourited, reblogged, etc.) across all buffers.
@@ -1029,6 +1042,8 @@ class MainGui(wx.Frame):
 		if selected_idx >= 0 and selected_idx < len(timelines):
 			account.currentTimeline = timelines[selected_idx]
 			account.currentIndex = selected_idx
+			if account.currentTimeline.type == "fusion":
+				account.currentTimeline.load()
 
 		# Update close timeline menu state
 		if account.currentTimeline and account.currentTimeline.removable:
@@ -1089,6 +1104,8 @@ class MainGui(wx.Frame):
 	def on_list_change(self, event):
 		get_app().currentAccount.currentTimeline=get_app().currentAccount.list_timelines()[self.list.GetSelection()]
 		get_app().currentAccount.currentIndex=self.list.GetSelection()
+		if get_app().currentAccount.currentTimeline.type == "fusion":
+			get_app().currentAccount.currentTimeline.load()
 		if get_app().currentAccount.currentTimeline.removable:
 			self.m_close_timeline.Enable(True)
 		else:
@@ -1133,20 +1150,40 @@ class MainGui(wx.Frame):
 		misc.havent_posted(get_app().currentAccount)
 
 	def refreshList(self):
-		stuffage=get_app().currentAccount.currentTimeline.get()
-		self.list2.Freeze()
-		# Use Set() for batch update - much faster than Clear() + individual Append()
-		self.list2.Set(stuffage)
 		tl = get_app().currentAccount.currentTimeline
-		count = self.list2.GetCount()
-		if count == 0:
-			# Empty list - ensure index is 0
-			tl.index = 0
-		else:
-			# Clamp index to valid range and set selection
-			tl.index = max(0, min(tl.index, count - 1))
-			self.list2.SetSelection(tl.index)
-		self.list2.Thaw()
+		top_item_id = None
+		if tl.type == "fusion" and hasattr(self.list2, "GetTopItem"):
+			try:
+				top_index = self.list2.GetTopItem()
+				previous_statuses = getattr(tl, "_previous_refresh_statuses", None)
+				if previous_statuses and 0 <= top_index < len(previous_statuses):
+					top_item_id = str(getattr(previous_statuses[top_index], "id", ""))
+			except Exception:
+				top_item_id = None
+		stuffage=tl.get()
+		self.list2.Freeze()
+		try:
+			self._programmatic_list2_selection = True
+			# Use Set() for batch update - much faster than Clear() + individual Append()
+			self.list2.Set(stuffage)
+			count = self.list2.GetCount()
+			if count == 0:
+				# Empty list - ensure index is 0
+				tl.index = 0
+			else:
+				# Clamp index to valid range and set selection
+				tl.index = max(0, min(tl.index, count - 1))
+				self.list2.SetSelection(tl.index)
+				if top_item_id and hasattr(self.list2, "SetFirstItem"):
+					for idx, item in enumerate(tl.statuses):
+						if str(getattr(item, "id", "")) == top_item_id:
+							self.list2.SetFirstItem(idx)
+							break
+		finally:
+			self._programmatic_list2_selection = False
+			self.list2.Thaw()
+			if hasattr(tl, "_previous_refresh_statuses"):
+				del tl._previous_refresh_statuses
 
 	def insertListItem(self, display_text, position=0):
 		"""Insert a single item at a position (for incremental streaming updates).
@@ -1173,7 +1210,11 @@ class MainGui(wx.Frame):
 		if new_count > 0:
 			tl.index = max(0, min(tl.index, new_count - 1))
 
-		self.list2.SetSelection(tl.index)
+		self._programmatic_list2_selection = True
+		try:
+			self.list2.SetSelection(tl.index)
+		finally:
+			self._programmatic_list2_selection = False
 		# Ensure the selection is visible
 		if tl.index >= 0:
 			self.list2.EnsureVisible(tl.index)
@@ -1188,6 +1229,10 @@ class MainGui(wx.Frame):
 		get_app().save_users()
 
 	def on_list2_change(self, event):
+		if getattr(self, "_programmatic_list2_selection", False):
+			if event:
+				event.Skip()
+			return
 		get_app().currentAccount.currentTimeline.index=self.list2.GetSelection()
 		# Track position change for timeline sync
 		get_app().currentAccount.currentTimeline.mark_position_moved()
@@ -1249,7 +1294,7 @@ class MainGui(wx.Frame):
 		# For other timelines, show the post viewer
 		status = self.get_current_status()
 		if status:
-			viewer = view.ViewGui(get_app().currentAccount, status)
+			viewer = view.ViewGui(self.get_current_status_account(), status)
 			viewer.Show()
 		else:
 			speak.speak("No messages in this conversation")
@@ -1979,7 +2024,7 @@ class MainGui(wx.Frame):
 	def OnUrl(self, event=None):
 		status = self.get_current_status()
 		if status:
-			misc.url_chooser(get_app().currentAccount, status)
+			misc.url_chooser(self.get_current_status_account(), status)
 
 	def OnTweetUrl(self, event=None):
 		status = self.get_current_status()
@@ -1996,7 +2041,8 @@ class MainGui(wx.Frame):
 				url = getattr(status.reblog, 'url', None)
 			if not url and hasattr(status, 'account'):
 				# Construct URL based on platform
-				platform_type = getattr(get_app().currentAccount.prefs, 'platform_type', 'mastodon')
+				account = self.get_current_status_account()
+				platform_type = getattr(account.prefs, 'platform_type', 'mastodon')
 				if platform_type == 'bluesky':
 					# Bluesky URL format: https://bsky.app/profile/{handle}/post/{rkey}
 					handle = getattr(status.account, 'acct', '') or getattr(status.account, 'handle', '')
@@ -2011,7 +2057,7 @@ class MainGui(wx.Frame):
 					url = f"https://bsky.app/profile/{handle}/post/{rkey}"
 				else:
 					# Mastodon URL format
-					url = f"{get_app().currentAccount.prefs.instance_url}/@{status.account.acct}/{status.id}"
+					url = f"{account.prefs.instance_url}/@{status.account.acct}/{status.id}"
 		if url:
 			if platform.system()!="Darwin":
 				webbrowser.open(url)
@@ -2191,35 +2237,35 @@ class MainGui(wx.Frame):
 	def OnReply(self, event=None):
 		status = self.get_current_status()
 		if status:
-			misc.reply(get_app().currentAccount, status)
+			misc.reply(self.get_current_status_account(), status)
 
 	def OnEdit(self, event=None):
 		status = self.get_current_status()
 		if status:
 			if not self._can_edit_status(status):
-				account = get_app().currentAccount
+				account = self.get_current_status_account()
 				if hasattr(account, 'supports_feature') and not account.supports_feature('editing'):
 					speak.speak("Editing posts is not supported on this platform")
 				else:
 					speak.speak("You can only edit your own posts")
 				return
-			misc.edit(get_app().currentAccount, status)
+			misc.edit(self.get_current_status_account(), status)
 
 	def OnQuote(self, event=None):
 		status = self.get_current_status()
 		if status:
-			misc.quote(get_app().currentAccount, status)
+			misc.quote(self.get_current_status_account(), status)
 
 	def OnMessage(self, event=None):
 		status = self.get_current_status()
 		if status:
-			misc.message(get_app().currentAccount, status)
+			misc.message(self.get_current_status_account(), status)
 
 	def OnLikeToggle(self, event=None):
 		"""Toggle favourite/like state for a status."""
 		status = self.get_current_status()
 		if status:
-			account = get_app().currentAccount
+			account = self.get_current_status_account()
 			try:
 				# Get the actual status (unwrap boosts) - need to interact with the original post
 				status_to_check = status.reblog if hasattr(status, 'reblog') and status.reblog else status
@@ -2256,7 +2302,7 @@ class MainGui(wx.Frame):
 		"""Toggle boost/retweet state for a status."""
 		status = self.get_current_status()
 		if status:
-			account = get_app().currentAccount
+			account = self.get_current_status_account()
 			try:
 				# Get the actual status (unwrap boosts) - need to interact with the original post
 				status_to_check = status.reblog if hasattr(status, 'reblog') and status.reblog else status
@@ -2355,7 +2401,7 @@ class MainGui(wx.Frame):
 		"""Toggle bookmark state for a status."""
 		status = self.get_current_status()
 		if status:
-			account = get_app().currentAccount
+			account = self.get_current_status_account()
 			platform_type = getattr(account.prefs, 'platform_type', 'mastodon')
 			if platform_type == 'bluesky':
 				speak.speak("Bookmarks are not supported on Bluesky")

--- a/application.py
+++ b/application.py
@@ -82,6 +82,7 @@ class Application:
 		self.currentAccount = None
 		self.timeline_settings = []
 		self._initialized = False
+		self._fusion_refresh_pending = False
 
 	@classmethod
 	def get_instance(cls):
@@ -283,6 +284,8 @@ class Application:
 			# account.folder_index work correctly (notably: removal renumbering).
 			self.accounts.sort(key=lambda a: getattr(a, 'folder_index', 0))
 
+		self.ensure_fusion_account()
+
 		self._initialized = True
 
 		# Check for updates on startup if enabled
@@ -306,13 +309,65 @@ class Application:
 			# would otherwise re-pick up as if it were a new account.
 			index = self._next_free_folder_index()
 		try:
-			self.accounts.append(t.mastodon(self, index))
+			self._remove_fusion_account()
+			account = t.mastodon(self, index)
+			self.accounts.append(account)
+			if getattr(self, '_initialized', False):
+				self.ensure_fusion_account()
+			return account
 		except t.AccountSetupCancelled:
+			if getattr(self, '_initialized', False):
+				self.ensure_fusion_account()
 			# User cancelled account setup - exit gracefully if no accounts
 			if len(self.accounts) == 0:
 				wx.CallAfter(wx.Exit)
 				return
 			# Otherwise just skip this account
+			return None
+
+	def _remove_fusion_account(self):
+		self.accounts = [a for a in self.accounts if not getattr(a, 'is_virtual', False)]
+
+	def ensure_fusion_account(self):
+		"""Ensure the virtual Fusion View account exists at the end of the account list."""
+		self._remove_fusion_account()
+		if not self.accounts:
+			return
+		from fusion_account import FusionAccount
+		self.accounts.append(FusionAccount(self))
+
+	def get_fusion_timeline(self):
+		for account in self.accounts:
+			if getattr(account, 'is_virtual', False):
+				return account.get_timeline_by_type('fusion')
+		return None
+
+	def get_fusion_timelines(self):
+		for account in self.accounts:
+			if getattr(account, 'is_virtual', False):
+				return [tl for tl in account.timelines if tl.type == 'fusion']
+		return []
+
+	def refresh_fusion_view(self):
+		"""Rebuild the Fusion View from currently loaded source timelines."""
+		for tl in self.get_fusion_timelines():
+			tl.load()
+
+	def refresh_fusion_view_soon(self):
+		"""Debounced Fusion refresh for bursts of streaming or refresh events."""
+		if self._fusion_refresh_pending:
+			return
+		self._fusion_refresh_pending = True
+
+		def do_refresh():
+			self._fusion_refresh_pending = False
+			self.refresh_fusion_view()
+
+		try:
+			import wx
+			wx.CallAfter(lambda: wx.CallLater(100, do_refresh))
+		except Exception:
+			do_refresh()
 
 	def _is_account_configured(self, index):
 		"""Check if an account has credentials saved (no dialogs needed)."""

--- a/build.py
+++ b/build.py
@@ -110,6 +110,7 @@ def get_hidden_imports():
         # Other modules
         "config",
         "timeline",
+        "fusion_account",
         "streaming",
         "mastodon_api",
         "application",
@@ -305,6 +306,12 @@ def build_windows(script_dir: Path, output_dir: Path) -> tuple:
 
     # Create zip file for distribution
     zip_path = create_windows_zip(output_dir, app_dir)
+
+    # PyInstaller leaves an intermediate executable in the work directory that
+    # looks runnable but cannot find the collected runtime DLLs beside it.
+    if build_dir.exists():
+        print(f"Removing intermediate build directory: {build_dir}")
+        shutil.rmtree(build_dir)
 
     return True, zip_path
 

--- a/fusion_account.py
+++ b/fusion_account.py
@@ -1,0 +1,87 @@
+"""Virtual Fusion View account.
+
+This account has no login or API backend. It exists so Fusion View can appear
+as its own top-level account while the real Mastodon and Bluesky accounts keep
+their normal timelines unchanged.
+"""
+
+import timeline
+from models import UniversalUser, UserCache
+
+
+class FusionPrefs(object):
+	def __init__(self):
+		self.platform_type = "fusion"
+		self.soundpack = "default"
+		self.soundpan = 0
+		self.soundpack_volume = 1.0
+		self.footer = ""
+		self.aliases = {}
+		self.timeline_order = []
+		self.mentions_in_notifications = False
+
+	def get(self, name, default=None):
+		return getattr(self, name, default)
+
+	def save(self):
+		pass
+
+
+class FusionAccount(object):
+	"""Non-authenticated virtual account for the Fusion View placeholder."""
+
+	is_virtual = True
+	folder_index = 999999
+
+	def __init__(self, app):
+		self.app = app
+		self.ready = True
+		self.timelines = []
+		self.currentIndex = 0
+		self.currentTimeline = None
+		self.currentStatus = None
+		self.confpath = ""
+		self.prefs = FusionPrefs()
+		self.me = UniversalUser(
+			id="fusion-view",
+			acct="Fusion View",
+			username="fusion",
+			display_name="Fusion View",
+			_platform="fastsm",
+		)
+		self.user_cache = UserCache("", "fusion", self.me.id)
+
+		for name, source_type in (
+			("Unified Timeline", "home"),
+			("Unified Mentions", "mentions"),
+			("Unified Notifications", "notifications"),
+		):
+			self.timelines.append(timeline.timeline(
+				self,
+				name=name,
+				type="fusion",
+				data=source_type,
+				silent=True,
+			))
+		self.currentTimeline = self.timelines[0]
+
+	def list_timelines(self, hidden=False):
+		return [tl for tl in self.timelines if tl.hide == hidden]
+
+	def get_first_timeline(self):
+		return self.timelines[0] if self.timelines else None
+
+	def get_timeline_by_type(self, timeline_type):
+		for tl in self.timelines:
+			if tl.type == timeline_type:
+				return tl
+		return None
+
+	def _on_timeline_initial_load_complete(self):
+		pass
+
+	def start_stream(self):
+		pass
+
+	def supports_feature(self, feature):
+		return False

--- a/mastodon_api.py
+++ b/mastodon_api.py
@@ -384,7 +384,14 @@ class mastodon(object):
 
 		# Initialize the client and login
 		handle = self.prefs.bluesky_handle
-		service = self.prefs.bluesky_service
+		service = (self.prefs.bluesky_service or "https://bsky.social").strip()
+		if not service.startswith(("http://", "https://")):
+			service = "https://" + service
+			self.prefs.bluesky_service = service
+			try:
+				self.prefs.save()
+			except:
+				pass
 		pw_len = len(self.prefs.bluesky_password or "")
 		if _logger:
 			_logger.info(
@@ -429,9 +436,6 @@ class mastodon(object):
 					exc_info=True,
 				)
 			speak.speak("Error logging into Bluesky: " + str(e))
-			# Clear credentials
-			self.prefs.bluesky_handle = ""
-			self.prefs.bluesky_password = ""
 			_exit_app()
 		except Exception as e:
 			if _logger:

--- a/streaming.py
+++ b/streaming.py
@@ -150,6 +150,7 @@ class MastodonStreamListener(StreamListener):
 								break
 					if needs_refresh:
 						main.window.refreshList()
+					self.account.app.refresh_fusion_view_soon()
 				except Exception as e:
 					if not self._is_network_error(e):
 						self.account.app.handle_error(e, "Stream delete (main thread)")
@@ -180,6 +181,7 @@ class MastodonStreamListener(StreamListener):
 								break
 					if needs_refresh:
 						main.window.refreshList()
+					self.account.app.refresh_fusion_view_soon()
 				except Exception as e:
 					if not self._is_network_error(e):
 						self.account.app.handle_error(e, "Stream status update (main thread)")

--- a/tests/test_timeline_fusion.py
+++ b/tests/test_timeline_fusion.py
@@ -1,0 +1,115 @@
+import types
+import sys
+import threading
+import unittest
+
+sys.modules["GUI.main"] = types.SimpleNamespace(
+	window=types.SimpleNamespace(refreshList=lambda: None)
+)
+
+import timeline
+
+
+class TimelineRefreshFocusTests(unittest.TestCase):
+	def _make_timeline(self, statuses, index):
+		tl = timeline.timeline.__new__(timeline.timeline)
+		tl.type = "home"
+		tl.statuses = list(statuses)
+		tl.index = index
+		tl.initial = False
+		tl.read = False
+		tl.mute = True
+		tl.hide = False
+		tl.name = "Home"
+		tl._position_moved = True
+		tl._status_ids = set(str(getattr(item, "id", "")) for item in statuses)
+		tl._status_lock = threading.Lock()
+		tl._gaps = []
+		tl.update_kwargs = {}
+		tl.prev_kwargs = {}
+		tl.account = types.SimpleNamespace(
+			me=types.SimpleNamespace(acct="user@example.com"),
+			user_cache=types.SimpleNamespace(add_users_from_status=lambda item: None),
+			timelines=[],
+			ready=True,
+		)
+		tl.app = types.SimpleNamespace(
+			prefs=types.SimpleNamespace(
+				reversed=False,
+				statuses_received=0,
+				fetch_pages=1,
+				single_api_on_startup=False,
+			),
+			currentAccount=None,
+			refresh_fusion_view_soon=lambda: None,
+			handle_error=lambda error, context: None,
+		)
+		tl._add_status_with_filter = lambda item, to_front=False: (
+			tl.statuses.insert(0, item) if to_front else tl.statuses.append(item)
+		) is None or True
+		return tl
+
+	def test_refresh_keeps_selected_item_when_newer_items_are_inserted(self):
+		old_items = [
+			types.SimpleNamespace(id="2"),
+			types.SimpleNamespace(id="1"),
+		]
+		tl = self._make_timeline(old_items, 1)
+
+		tl._do_load(items=[types.SimpleNamespace(id="3")])
+
+		self.assertEqual(tl.index, 2)
+		self.assertEqual(tl.statuses[tl.index].id, "1")
+
+
+class FusionTimelineFocusTests(unittest.TestCase):
+	def _make_fusion_timeline(self, statuses, index, refreshed_statuses):
+		tl = timeline.timeline.__new__(timeline.timeline)
+		tl.type = "fusion"
+		tl.statuses = statuses
+		tl.index = index
+		tl.func = lambda: refreshed_statuses
+		tl._status_ids = set(str(getattr(item, "id", "")) for item in statuses)
+		tl.initial = False
+		tl.account = types.SimpleNamespace()
+		tl.app = types.SimpleNamespace(currentAccount=None)
+		tl.name = "Fusion View"
+		return tl
+
+	def test_fusion_refresh_keeps_selected_item_when_newer_items_are_inserted(self):
+		old_items = [
+			types.SimpleNamespace(id="2"),
+			types.SimpleNamespace(id="1"),
+		]
+		refreshed_items = [
+			types.SimpleNamespace(id="3"),
+			types.SimpleNamespace(id="2"),
+			types.SimpleNamespace(id="1"),
+		]
+		tl = self._make_fusion_timeline(old_items, 1, refreshed_items)
+
+		self.assertTrue(tl.load())
+
+		self.assertEqual(tl.index, 2)
+		self.assertEqual(tl.statuses[tl.index].id, "1")
+		self.assertEqual(tl._previous_refresh_statuses, old_items)
+
+	def test_fusion_refresh_clamps_index_when_selected_item_disappears(self):
+		old_items = [
+			types.SimpleNamespace(id="2"),
+			types.SimpleNamespace(id="1"),
+		]
+		refreshed_items = [
+			types.SimpleNamespace(id="4"),
+			types.SimpleNamespace(id="3"),
+		]
+		tl = self._make_fusion_timeline(old_items, 1, refreshed_items)
+
+		self.assertTrue(tl.load())
+
+		self.assertEqual(tl.index, 1)
+		self.assertEqual(tl.statuses[tl.index].id, "3")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/timeline.py
+++ b/timeline.py
@@ -5,7 +5,46 @@ import sound
 import threading
 import os
 import wx
+from datetime import datetime, timezone
 from GUI import main
+from models import UniversalStatus, UniversalUser
+
+
+class FusionTimelineItem(object):
+	"""Normalized item for the virtual Fusion timeline."""
+
+	def __init__(self, source, source_account, item_type, author, timestamp, time_text, text, post_url, original):
+		self.source = source
+		self.source_account = source_account
+		self.item_type = item_type
+		self.author = author
+		self.timestamp = timestamp
+		self.time_text = time_text
+		self.text = text
+		self.post_url = post_url
+		self.original = original
+		self.id = f"fusion:{item_type}:{source}:{getattr(source_account.me, 'id', '')}:{getattr(original, 'id', '')}"
+		self.created_at = timestamp
+		self.account = getattr(original, 'account', None)
+		self.reblog = getattr(original, 'reblog', None)
+		self.quote = getattr(original, 'quote', None)
+		self.favourited = getattr(original, 'favourited', False)
+		self.reblogged = getattr(original, 'reblogged', False)
+		self.bookmarked = getattr(original, 'bookmarked', False)
+		self.url = post_url
+		self._fusion_item = True
+		self._display_cache = self.accessible_label()
+
+	def accessible_label(self):
+		prefix = self.source
+		if self.author:
+			prefix += f", {self.author}"
+		label = prefix
+		if self.text:
+			label += f": {self.text}"
+		if self.time_text:
+			label += f" {self.time_text}"
+		return label
 
 
 class TimelineSettings(object):
@@ -216,6 +255,8 @@ class timeline(object):
 			status_id = self.data
 			self.func = lambda sid=status_id, **kwargs: self.account.api._Mastodon__api_request('GET', f'/api/v1/statuses/{sid}/quotes')
 			self.removable = True
+		elif self.type == "fusion":
+			self.func = self._load_fusion_items
 
 		# Load saved filter settings if any
 		from GUI.timeline_filter import get_saved_filter
@@ -243,6 +284,76 @@ class timeline(object):
 				return self.account._platform.get_remote_user_timeline(self._remote_url, self._remote_username, filter=self._remote_filter, **kwargs)
 			return self.account._platform.get_remote_user_timeline(self._remote_url, self._remote_username, **kwargs)
 		return []
+
+	def _load_fusion_placeholder(self, **kwargs):
+		"""Return a single accessible placeholder item for the future Fusion View."""
+		user = UniversalUser(
+			id="fusion-view",
+			acct="fusion-view",
+			username="fusion-view",
+			display_name="Fusion View",
+			_platform="fastsm",
+		)
+		return [UniversalStatus(
+			id="fusion-view-placeholder",
+			account=user,
+			content="Fusion View placeholder. Unified Mastodon and Bluesky timelines are not connected yet.",
+			text="Fusion View placeholder. Unified Mastodon and Bluesky timelines are not connected yet.",
+			created_at=datetime.now(timezone.utc),
+			_platform="fastsm",
+		)]
+
+	def _normalize_fusion_timestamp(self, value):
+		if isinstance(value, datetime):
+			if value.tzinfo is None:
+				return value.replace(tzinfo=timezone.utc)
+			return value
+		if isinstance(value, str):
+			try:
+				parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+				if parsed.tzinfo is None:
+					return parsed.replace(tzinfo=timezone.utc)
+				return parsed
+			except ValueError:
+				pass
+		return datetime.min.replace(tzinfo=timezone.utc)
+
+	def _load_fusion_items(self, **kwargs):
+		"""Combine already-loaded timeline items from real accounts."""
+		source_timeline_type = self.data or "home"
+		items = []
+		for account in self.app.accounts:
+			if account is self.account or getattr(account, 'is_virtual', False):
+				continue
+			platform_type = getattr(account.prefs, 'platform_type', '')
+			if platform_type not in ('mastodon', 'bluesky'):
+				continue
+			source_timeline = account.get_timeline_by_type(source_timeline_type) if hasattr(account, 'get_timeline_by_type') else None
+			if not source_timeline:
+				continue
+			source = "Mastodon" if platform_type == "mastodon" else "Bluesky"
+			for item in list(getattr(source_timeline, 'statuses', [])):
+				if source_timeline_type == "notifications":
+					status_for_url = getattr(item, 'status', None)
+					author_obj = getattr(item, 'account', None)
+					timestamp = self._normalize_fusion_timestamp(getattr(item, 'created_at', None))
+					text = self.app.process_notification(item, account=account)
+					post_url = getattr(status_for_url, 'url', None) if status_for_url else None
+				else:
+					author_obj = getattr(item, 'account', None)
+					timestamp = self._normalize_fusion_timestamp(getattr(item, 'created_at', None))
+					text = self.app.process_status(item, return_only_text=True, account=account)
+					post_url = getattr(item, 'url', None)
+				author = ""
+				if author_obj:
+					author = getattr(author_obj, 'display_name', '') or getattr(author_obj, 'acct', '')
+				time_text = self.app.parse_date(timestamp)
+				items.append(FusionTimelineItem(source, account, source_timeline_type, author, timestamp, time_text, text, post_url, item))
+
+		items.sort(key=lambda item: item.timestamp, reverse=True)
+		if items:
+			return items
+		return self._load_fusion_placeholder()
 
 	def _search_statuses(self, **kwargs):
 		"""Helper to search and return only statuses"""
@@ -1114,6 +1225,36 @@ class timeline(object):
 		return all_results
 
 	def load(self, back=False, speech=False, items=[]):
+		if self.type == "fusion" and items == []:
+			previous_statuses = list(self.statuses)
+			current_id = None
+			if self.statuses and 0 <= self.index < len(self.statuses):
+				current_id = str(getattr(self.statuses[self.index], 'id', ''))
+			fusion_items = self.func()
+			self._previous_refresh_statuses = previous_statuses
+			self.statuses = fusion_items
+			self._status_ids = set(str(getattr(item, 'id', '')) for item in fusion_items)
+			self.invalidate_display_cache()
+			if not self.statuses:
+				self.index = 0
+			elif current_id:
+				for idx, item in enumerate(self.statuses):
+					if str(getattr(item, 'id', '')) == current_id:
+						self.index = idx
+						break
+				else:
+					self.index = max(0, min(self.index, len(self.statuses) - 1))
+			else:
+				self.index = max(0, min(self.index, len(self.statuses) - 1))
+			if self.initial:
+				self.initial = False
+				if hasattr(self.account, '_on_timeline_initial_load_complete'):
+					self.account._on_timeline_initial_load_complete()
+			if self.app.currentAccount == self.account and self.account.currentTimeline == self:
+				wx.CallAfter(main.window.refreshList)
+			if speech:
+				speak.speak(f"{len(self.statuses)} items in {self.name}")
+			return True
 		if self.hide:
 			# Still notify if this was an initial load that got skipped
 			if self.initial:
@@ -1562,6 +1703,11 @@ class timeline(object):
 		else:
 			tl = items
 		if tl is not None:
+			selected_status_id = None
+			if not self.initial and self.statuses and 0 <= self.index < len(self.statuses):
+				selected_status = self.statuses[self.index]
+				selected_status_id = str(getattr(selected_status, '_scheduled_id', None) or getattr(selected_status, 'id', ''))
+
 			# Sort scheduled posts by scheduled date (soonest first)
 			if self.type == "scheduled" and tl:
 				tl = sorted(tl, key=lambda x: getattr(x, '_scheduled_at', None) or getattr(x, 'scheduled_at', None) or '')
@@ -1624,8 +1770,8 @@ class timeline(object):
 							filtered_objs2.append(i)
 					objs2 = filtered_objs2
 
-				if self.app.currentAccount == self.account and self.account.currentTimeline == self:
-					wx.CallAfter(main.window.refreshList)
+				if self.type in ("home", "mentions", "notifications"):
+					self.app.refresh_fusion_view_soon()
 
 				if items == []:
 					# Don't set since_id for timelines that use internal pagination IDs
@@ -1657,20 +1803,21 @@ class timeline(object):
 					import time
 					self._last_load_time = time.time()
 
-				# Adjust index when items are added before current position
-				if not back and not self.initial:
-					if not self.app.prefs.reversed:
-						# New items added at front, shift index to stay on same item
-						self.index += len(objs2)
-				if back and self.app.prefs.reversed:
-					# Previous items added at front, shift index to stay on same item
-					self.index += len(objs2)
+				# Keep focus on the same post even when refresh inserts new items above it.
+				if selected_status_id:
+					for idx, item in enumerate(self.statuses):
+						item_id = str(getattr(item, '_scheduled_id', None) or getattr(item, 'id', ''))
+						if item_id == selected_status_id:
+							self.index = idx
+							break
 
 				if self.initial:
 					if not self.app.prefs.reversed:
 						self.index = 0
 					else:
 						self.index = len(self.statuses) - 1
+				if self.app.currentAccount == self.account and self.account.currentTimeline == self:
+					wx.CallAfter(main.window.refreshList)
 				if not self.mute and not self.hide and len(objs2) > 0:
 					self.play(objs2)
 				self.app.prefs.statuses_received += newitems
@@ -1743,6 +1890,8 @@ class timeline(object):
 		if self.account.timelines and self == self.account.timelines[-1] and not self.account.ready:
 			self.account.ready = True
 			sound.play(self.account, "ready")
+		if self.type in ("home", "mentions", "notifications"):
+			self.app.refresh_fusion_view_soon()
 
 	def toggle_read(self):
 		if self.read:
@@ -1765,6 +1914,16 @@ class timeline(object):
 		self.app.save_timeline_settings()
 
 	def get(self):
+		if self.type == "fusion":
+			items = []
+			for item in self.statuses:
+				display = getattr(item, '_display_cache', None)
+				if display is None and hasattr(item, 'accessible_label'):
+					display = item.accessible_label()
+				if display is None:
+					display = self.app.process_status(item, account=self.account)
+				items.append(display)
+			return items
 		# Return cached display list if available and valid
 		if hasattr(self, '_display_list_cache') and self._display_list_cache is not None:
 			if len(self._display_list_cache) == len(self.statuses):


### PR DESCRIPTION
Created an option in accounts to choose to see all added accounts in a chronological view called a fussion session. Presently you can boost and reply with in this view.