### PR TITLE
Add Linux .deb/.rpm package building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,18 +259,46 @@ jobs:
           FASTSM_BUNDLE_LIBSSL_DIR: ${{ github.workspace }}
         run: python build.py
 
-      - name: Find build artifact
+      - name: Install fpm for native packaging
+        run: |
+          sudo gem install fpm
+
+      - name: Build native packages (.deb, .rpm)
+        run: |
+          DIST_DIR="$HOME/app_dist/FastSM/dist/FastSM"
+          VERSION=$(python -c "from version import APP_VERSION; print(APP_VERSION)")
+          bash packaging/linux/build_packages.sh "$DIST_DIR" "$VERSION"
+
+      - name: Find build artifacts
         id: artifact
         run: |
           TAR=$(ls FastSM-Linux-Portable.tar.gz 2>/dev/null | head -1)
           echo "path=$TAR" >> $GITHUB_OUTPUT
           echo "name=$TAR" >> $GITHUB_OUTPUT
+          DEB=$(ls FastSM_*.deb 2>/dev/null | head -1)
+          echo "deb_path=$DEB" >> $GITHUB_OUTPUT
+          echo "deb_name=$DEB" >> $GITHUB_OUTPUT
+          RPM=$(ls FastSM-*.rpm 2>/dev/null | head -1)
+          echo "rpm_path=$RPM" >> $GITHUB_OUTPUT
+          echo "rpm_name=$RPM" >> $GITHUB_OUTPUT
 
-      - name: Upload Linux artifact
+      - name: Upload Linux tarball artifact
         uses: actions/upload-artifact@v4
         with:
           name: linux-build
           path: ${{ steps.artifact.outputs.path }}
+
+      - name: Upload Linux .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-deb
+          path: ${{ steps.artifact.outputs.deb_path }}
+
+      - name: Upload Linux .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-rpm
+          path: ${{ steps.artifact.outputs.rpm_path }}
 
   release:
     # Skip on push so we don't churn the latest release on every commit.
@@ -343,6 +371,18 @@ jobs:
           name: linux-build
           path: artifacts/
 
+      - name: Download Linux .deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-deb
+          path: artifacts/
+
+      - name: Download Linux .rpm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-rpm
+          path: artifacts/
+
       - name: List artifacts
         run: ls -la artifacts/
 
@@ -370,6 +410,8 @@ jobs:
             - **Windows Portable:** FastSM-Windows-Portable.zip
             - **macOS:** FastSM-${{ steps.version.outputs.version }}.dmg
             - **Linux Portable:** FastSM-Linux-Portable.tar.gz
+            - **Linux (.deb):** FastSM_${{ steps.version.outputs.version }}_amd64.deb
+            - **Linux (.rpm):** FastSM-${{ steps.version.outputs.version }}-1.x86_64.rpm
           files: artifacts/*
           prerelease: true
           make_latest: false

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,8 @@ vlc/
 # yt-dlp executable (download from https://github.com/yt-dlp/yt-dlp/releases)
 yt-dlp.exe
 
+# Linux packages (built locally or in CI)
+*.deb
+*.rpm
+
 todo.txt

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Prebuilt binaries for every commit to `master` are published at the [latest rele
 - **Windows Portable**: `FastSM-Windows-Portable.zip`
 - **macOS**: `FastSM-<version>.dmg`
 - **Linux Portable**: `FastSM-Linux-Portable.tar.gz`
+- **Linux (.deb)**: `FastSM_<version>_amd64.deb` (Debian/Ubuntu)
+- **Linux (.rpm)**: `FastSM-<version>-1.x86_64.rpm` (Fedora/RHEL)
 
 ## Running from source
 
@@ -82,6 +84,38 @@ Produces a signed `.app` inside a DMG. Uses ad-hoc signing (`-`) if no Developer
 ### Linux
 
 Produces a `.tar.gz` of a PyInstaller onedir bundle. The build script post-processes the bundle to remove libraries that must come from the user's system (GLib family, libasound, libpulse, util-linux, etc.) — bundling these causes ABI mismatches on distros newer than the build runner.
+
+### Linux packages
+
+PyInstaller builds can also be wrapped into native `.deb` and `.rpm` packages for easier installation:
+
+```bash
+# Build the PyInstaller bundle first, then package it
+python build.py
+python build.py --package
+
+# The packages appear in the current directory:
+#   FastSM_<version>_amd64.deb
+#   FastSM-<version>-1.x86_64.rpm
+```
+
+On Debian/Ubuntu, install the `.deb` with:
+
+```bash
+sudo dpkg -i FastSM_<version>_amd64.deb
+# Install any missing dependencies:
+sudo apt-get install -f
+```
+
+On Fedora/RHEL, install the `.rpm` with:
+
+```bash
+sudo dnf install FastSM-<version>-1.x86_64.rpm
+```
+
+The packages install FastSM to `/opt/FastSM/` and register a desktop entry. Run `fastsm` from a terminal or launch from the application menu.
+
+Requires [fpm](https://github.com/jordansissel/fpm) (`gem install fpm` or `apt-get install ruby-fpm`).
 
 ### Continuous integration
 

--- a/build.py
+++ b/build.py
@@ -752,9 +752,63 @@ def create_macos_dmg(output_dir: Path, app_path: Path, script_dir: Path) -> Path
     return dmg_path
 
 
+def build_linux_packages(script_dir: Path, app_dir: Path):
+    """Build .deb and .rpm packages from the Linux PyInstaller output.
+
+    Uses packaging/linux/build_packages.sh which requires fpm.
+    If fpm is not installed, prints a warning and skips packaging.
+
+    Returns:
+        List of package paths created, or empty list.
+    """
+    print("Building native Linux packages (.deb, .rpm)...")
+
+    packaging_script = script_dir / "packaging" / "linux" / "build_packages.sh"
+    if not packaging_script.exists():
+        print("Warning: packaging script not found, skipping native packages")
+        return []
+
+    version = APP_VERSION
+
+    try:
+        result = subprocess.run(
+            ["bash", str(packaging_script), str(app_dir), str(version), str(script_dir)],
+            capture_output=True, text=True, cwd=script_dir
+        )
+        print(result.stdout)
+        if result.returncode != 0:
+            print(f"Warning: packaging failed:\n{result.stderr}")
+            return []
+
+        packages = list(script_dir.glob("*.deb")) + list(script_dir.glob("*.rpm"))
+        for pkg in packages:
+            print(f"  Package created: {pkg.name}")
+        return packages
+
+    except FileNotFoundError:
+        print("Warning: bash not found, skipping native packages")
+        return []
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=f"Build {APP_NAME} v{APP_VERSION} using PyInstaller"
+    )
+    parser.add_argument(
+        "--package", action="store_true",
+        help="Also build native packages (.deb, .rpm) on Linux"
+    )
+    return parser.parse_args()
+
+
 def main():
     """Build FastSM executable using PyInstaller."""
     script_dir = Path(__file__).parent.resolve()
+
+    args = parse_args()
 
     platform = get_platform()
     print(f"Detected platform: {platform}")
@@ -786,6 +840,15 @@ def main():
             print(f"Copying to source folder: {dest_path}")
             shutil.copy2(artifact_path, dest_path)
             print(f"Artifact: {dest_path}")
+
+        # Build native packages on Linux if requested
+        if platform == "linux" and args.package:
+            # app_dir is the PyInstaller output directory
+            app_dir = output_dir / "dist" / APP_NAME
+            if app_dir.exists():
+                build_linux_packages(script_dir, app_dir)
+            else:
+                print(f"Warning: app directory not found for packaging: {app_dir}")
 
         print("=" * 50)
     else:

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: FastSM
+Upstream-Contact: Mew
+Source: https://github.com/masonasons/FastSM
+
+Files: *
+Copyright: 2026 Mew
+License: All Rights Reserved

--- a/packaging/linux/build_packages.sh
+++ b/packaging/linux/build_packages.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Build .deb and .rpm packages from a PyInstaller Linux build output.
+#
+# Usage:
+#   ./packaging/linux/build_packages.sh <dist_dir> <version> [output_dir]
+#
+#   dist_dir    - Path to the PyInstaller output directory (e.g. ~/app_dist/FastSM/dist/FastSM)
+#   version     - Version string (e.g. 0.5.0)
+#   output_dir  - Where to write the packages (default: current directory)
+#
+# Requires: fpm (effing package management)
+# Install: gem install fpm
+#          or  apt-get install ruby-fpm
+
+set -euo pipefail
+
+DIST_DIR="${1:?Usage: $0 <dist_dir> <version> [output_dir]}"
+VERSION="${2:?Usage: $0 <dist_dir> <version> [output_dir]}"
+OUTPUT_DIR="${3:-$(pwd)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+APP_NAME="FastSM"
+APP_DESCRIPTION="A fast, accessible social media client for Mastodon and Bluesky"
+APP_URL="https://github.com/masonasons/FastSM"
+APP_VENDOR="Mew"
+APP_MAINTAINER="Mew"
+APP_LICENSE="All Rights Reserved"
+APP_ARCH="amd64"
+
+# Dependencies that the PyInstaller bundle needs at runtime on the host system
+DEB_DEPENDS=(
+    "libgtk-3-0"
+    "libnotify4"
+    "libsdl2-2.0-0"
+    "libasound2"
+    "libpulse0"
+    "libgstreamer1.0-0"
+    "libgstreamer-plugins-base1.0-0"
+)
+
+RPM_DEPENDS=(
+    "gtk3"
+    "libnotify"
+    "SDL2"
+    "alsa-lib"
+    "pulseaudio-libs"
+    "gstreamer1"
+    "gstreamer1-plugins-base"
+)
+
+# --- Check prerequisites ---
+if ! command -v fpm &>/dev/null; then
+    echo "fpm is required. Install it with:"
+    echo "  gem install fpm"
+    echo "  # or"
+    echo "  apt-get install ruby-fpm"
+    exit 1
+fi
+
+if [ ! -d "$DIST_DIR" ]; then
+    echo "Error: dist directory not found: $DIST_DIR"
+    exit 1
+fi
+
+echo "=========================================="
+echo "Building Linux packages for $APP_NAME v$VERSION"
+echo "=========================================="
+echo "Dist dir:  $DIST_DIR"
+echo "Output:    $OUTPUT_DIR"
+echo
+
+# --- Build Debian package ---
+echo "--- Building .deb ---"
+fpm \
+    --input-type dir \
+    --output-type deb \
+    --name "$APP_NAME" \
+    --version "$VERSION" \
+    --architecture "$APP_ARCH" \
+    --vendor "$APP_VENDOR" \
+    --maintainer "$APP_MAINTAINER" \
+    --description "$APP_DESCRIPTION" \
+    --url "$APP_URL" \
+    --license "$APP_LICENSE" \
+    --category "net" \
+    --package "$OUTPUT_DIR/${APP_NAME}_${VERSION}_${APP_ARCH}.deb" \
+    --force \
+    --deb-user root \
+    --deb-group root \
+    --deb-priority optional \
+    --deb-field "Section: net" \
+    --verbose \
+    $(for d in "${DEB_DEPENDS[@]}"; do echo --depends "$d"; done) \
+    "$DIST_DIR=/opt/$APP_NAME" \
+    "$PROJECT_DIR/packaging/linux/fastsm.desktop=/usr/share/applications/$APP_NAME.desktop" \
+    "$PROJECT_DIR/packaging/debian/copyright=/usr/share/doc/$APP_NAME/copyright" \
+    "$PROJECT_DIR/docs/=/usr/share/doc/$APP_NAME/"
+
+echo
+
+# --- Build RPM package ---
+echo "--- Building .rpm ---"
+fpm \
+    --input-type dir \
+    --output-type rpm \
+    --name "$APP_NAME" \
+    --version "$VERSION" \
+    --architecture x86_64 \
+    --vendor "$APP_VENDOR" \
+    --maintainer "$APP_MAINTAINER" \
+    --description "$APP_DESCRIPTION" \
+    --url "$APP_URL" \
+    --license "$APP_LICENSE" \
+    --category "Network" \
+    --package "$OUTPUT_DIR/${APP_NAME}-${VERSION}-1.x86_64.rpm" \
+    --force \
+    --rpm-user root \
+    --rpm-group root \
+    --verbose \
+    $(for d in "${RPM_DEPENDS[@]}"; do echo --depends "$d"; done) \
+    "$DIST_DIR=/opt/$APP_NAME" \
+    "$PROJECT_DIR/packaging/linux/fastsm.desktop=/usr/share/applications/$APP_NAME.desktop" \
+    "$PROJECT_DIR/docs/=/usr/share/doc/$APP_NAME/"
+
+echo
+echo "=========================================="
+echo "Packages created:"
+ls -lh "$OUTPUT_DIR/"*.deb "$OUTPUT_DIR/"*.rpm 2>/dev/null || true
+echo "=========================================="

--- a/packaging/linux/fastsm.desktop
+++ b/packaging/linux/fastsm.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=FastSM
+Comment=A fast, accessible social media client for Mastodon and Bluesky
+Exec=fastsm
+Icon=fastsm
+Terminal=false
+Categories=Network;Chat;Accessibility;
+StartupNotify=true
+Keywords=mastodon;bluesky;social;accessibility;


### PR DESCRIPTION
Add native Linux packaging support for FastSM, making installation much simpler on Debian/Ubuntu (.deb) and Fedora/RHEL (.rpm).

### What's included

- **New files:**
  - `packaging/linux/build_packages.sh` � uses `fpm` to build both package formats from the PyInstaller output
  - `packaging/linux/fastsm.desktop` � XDG desktop entry for app menu integration
  - `packaging/debian/copyright` � Debian copyright metadata

- **Modified files:**
  - `build.py` � added `--package` flag that calls the packaging script on Linux
  - `.github/workflows/build.yml` � installs fpm, runs packaging, uploads .deb/.rpm as artifacts, includes in release
  - `README.md` � documents package install instructions
  - `.gitignore` � ignores *.deb and *.rpm build artifacts

### How it works in CI

After the PyInstaller Linux build completes, `fpm` wraps the output into .deb and .rpm packages that:
- Install the binary bundle to `/opt/FastSM/`
- Register the desktop entry at `/usr/share/applications/fastsm.desktop`
- Copy docs to `/usr/share/doc/fastsm/`
- Declare runtime dependencies (GTK3, libnotify, SDL2, ALSA, PulseAudio, GStreamer)

### Local usage
```
python build.py
python build.py --package
bash packaging/linux/build_packages.sh ~/app_dist/FastSM/dist/FastSM 0.5.0
```

### Note
The copyright file currently says "All Rights Reserved" since the project has no LICENSE file. You may want to update `packaging/debian/copyright` and the `APP_LICENSE` variable in `build_packages.sh` once a license is chosen.
